### PR TITLE
Alerts adjustments

### DIFF
--- a/Alert Service/main.py
+++ b/Alert Service/main.py
@@ -239,7 +239,6 @@ def on_forecast_stream_received_handler(stream_consumer: qx.StreamConsumer):
         if stream_id in alerts_triggered:
             del alerts_triggered[stream_id]
 
-        stream_alerts_producer.close()
         print(f"Closing stream '{closed_stream_consumer.properties.name}'")
 
     stream_consumer.on_stream_closed = on_stream_close

--- a/Alert Service/main.py
+++ b/Alert Service/main.py
@@ -151,6 +151,7 @@ def on_forecast_dataframe_received(stream_consumer: qx.StreamConsumer, fcast: pd
     low_threshold = THRESHOLDS[parameter_name][0]
     high_threshold = THRESHOLDS[parameter_name][1]
 
+    print(stream_consumer.stream_id)
     suffix_to_remove = "-down-sampled-forecast"
     if stream_consumer.stream_id.endswith(suffix_to_remove):
         stream_id = stream_consumer.stream_id[:-len(suffix_to_remove)]

--- a/quix.yaml
+++ b/quix.yaml
@@ -56,7 +56,7 @@ deployments:
     deploymentType: Service
     version: 893744e3f58b304b125e7d313477e0dd95ce121b
     resources:
-      cpu: 500
+      cpu: 1000
       memory: 1000
       replicas: 1
     desiredStatus: Running

--- a/quix.yaml
+++ b/quix.yaml
@@ -252,7 +252,7 @@ deployments:
   - name: Alert Service
     application: Alert Service
     deploymentType: Service
-    version: 547bea4e8109836a386beb5b0319433dcb6c60c1
+    version: a14783b36c5e24247bb58fc0b813fb55b568e2dd
     resources:
       cpu: 200
       memory: 500

--- a/quix.yaml
+++ b/quix.yaml
@@ -257,7 +257,7 @@ deployments:
       cpu: 200
       memory: 500
       replicas: 1
-    desiredStatus: Stopped
+    desiredStatus: Running
     variables:
       - name: alerts
         inputType: OutputTopic

--- a/quix.yaml
+++ b/quix.yaml
@@ -252,7 +252,7 @@ deployments:
   - name: Alert Service
     application: Alert Service
     deploymentType: Service
-    version: a14783b36c5e24247bb58fc0b813fb55b568e2dd
+    version: 4de34b2ed88d83e54ab7fc60ee48fa8e1f4cd31d
     resources:
       cpu: 1000
       memory: 500

--- a/quix.yaml
+++ b/quix.yaml
@@ -257,7 +257,7 @@ deployments:
       cpu: 200
       memory: 500
       replicas: 1
-    desiredStatus: Running
+    desiredStatus: Stopped
     variables:
       - name: alerts
         inputType: OutputTopic

--- a/quix.yaml
+++ b/quix.yaml
@@ -254,7 +254,7 @@ deployments:
     deploymentType: Service
     version: a14783b36c5e24247bb58fc0b813fb55b568e2dd
     resources:
-      cpu: 200
+      cpu: 1000
       memory: 500
       replicas: 1
     desiredStatus: Running

--- a/quix.yaml
+++ b/quix.yaml
@@ -252,7 +252,7 @@ deployments:
   - name: Alert Service
     application: Alert Service
     deploymentType: Service
-    version: a6767d9871a277d2469acb37daab5d04ed899213
+    version: 547bea4e8109836a386beb5b0319433dcb6c60c1
     resources:
       cpu: 200
       memory: 500


### PR DESCRIPTION
Add parameter name to no-alert.
Send over-now or under-now alerts every minute.
Rename forecast alert stream.
Increase cpu